### PR TITLE
[#3] Setup CD: Fix the wrong config on staging deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Set staging environment variables
         if: github.ref == 'refs/heads/develop'
         run: |
-          echo "NETLIFY_ALIAS=${{ github.head_ref }}" >> $GITHUB_ENV
+          echo "NETLIFY_ALIAS=develop" >> $GITHUB_ENV
           echo "NETLIFY_PRODUCTION_DEPLOYMENT=false" >> $GITHUB_ENV
           echo "NETLIFY_MESSAGE=Staging Deploy from GitHub Actions" >> $GITHUB_ENV
 


### PR DESCRIPTION
Resolve https://github.com/carryall/react-survey-challenge/issues/3

## What happened 👀

After merging [this PR](https://github.com/carryall/react-survey-challenge/pull/28) to set up the CD, the configured of `NETLIFY_ALIAS` was missing on [this run](https://github.com/carryall/react-survey-challenge/runs/3950846862?check_suite_focus=true) 

![Screen Shot 2564-10-20 at 18 42 57](https://user-images.githubusercontent.com/1772999/138086683-e1095345-4373-49c9-ba10-32445003175f.png)

because the `github.head_ref` which used for the value only work on the workflow that trigger by pull request

![Screen Shot 2564-10-20 at 18 47 02](https://user-images.githubusercontent.com/1772999/138086890-d499299d-80db-4b9e-a8f2-f79e9820b58d.png)

so I decided to use the static value instead

## Insight 📝

N/A

## Proof Of Work 📹

N/A
